### PR TITLE
Fix typo in greatlte / Note8 build fingerprint

### DIFF
--- a/lineage_greatlte.mk
+++ b/lineage_greatlte.mk
@@ -39,4 +39,4 @@ PRODUCT_BUILD_PROP_OVERRIDES += \
     PRODUCT_NAME=greatltexx \
     PRIVATE_BUILD_DESC="greatltexx-user 8.0.0 R16NW N950FXXU3CRC1 release-keys"
 
-BUILD_FINGERPRINT := samsung/greatltexx/dreamlte:8.0.0/R16NW/N950FXXU3CRC1:user/release-keys
+BUILD_FINGERPRINT := samsung/greatltexx/greatlte:8.0.0/R16NW/N950FXXU3CRC1:user/release-keys


### PR DESCRIPTION
This should improve safetynet support as the fingerprint is now valid.